### PR TITLE
ci: remove regular build from CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,17 +9,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build_regular:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Prepare environment
-        run: |
-          sudo apt-get update && sudo apt-get install -y g++-13
-          echo "CXX=g++-13" >> $GITHUB_ENV
-      - name: Build CMake Project
-        uses: threeal/cmake-action@v2.1.0
-
   build_nix_shell:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Something in the underlying image changed, and the CMake build does not find rustc compiler anymore (despite rustc still being available). The effort to reproduce the setup locally and find the issue, as well as similar maintenance in the future, is not worth the considerable amount of time. Thus, we remove the regular build from the CI and keep only the reproducable Nix-based builds.